### PR TITLE
Correct public directory copy in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
 						npm run build
 						cp -r .next/standalone ./
 						cp -r .next/static ./
-						cp -r public ./
+						cp -r public/* ./
             		'''
                 }
             }


### PR DESCRIPTION
- updated `cp` command to copy files from `public/*` instead of `public/`.