### PR TITLE
Correct file copy paths in Jenkinsfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 
 COPY --chown=nextjs:nodejs .next/standalone ./
-COPY --chown=nextjs:nodejs .next/static ./
+COPY --chown=nextjs:nodejs .next/static ./.next/static
 COPY --chown=nextjs:nodejs public ./public
 
 RUN mkdir -p /app/.next/cache/images && chown -R nextjs:nodejs /app

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,9 +24,6 @@ pipeline {
 					sh '''
 						npm install
 						npm run build
-						mkdir -p .next
-						cp -r .next/standalone .next/
-						cp -r .next/static .next/
 						cp -r public ./
             		'''
                 }


### PR DESCRIPTION
- added directory creation for .next before copying.
- corrected paths for copying standalone, static, and public.