### PR TITLE
Correct Dockerfile and Jenkinsfile build steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,11 @@ ENV NEXT_TELEMETRY_DISABLED=1
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 
-#COPY --chown=nextjs:nodejs .next/standalone ./
-#COPY --chown=nextjs:nodejs .next/static ./.next/static
-#COPY --chown=nextjs:nodejs public ./public
-
 RUN mkdir -p /app/.next/cache/images && chown -R nextjs:nodejs /app
 
-RUN cp -r public .next/standalone/ && cp -r .next/static .next/standalone/.next/
+COPY --chown=nextjs:nodejs .next/standalone ./
+COPY --chown=nextjs:nodejs .next/static ./.next/static
+COPY --chown=nextjs:nodejs public ./public
 
 USER nextjs
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,6 +24,7 @@ pipeline {
 					sh '''
 						npm install
 						npm run build
+						ls -la .next
             		'''
                 }
             }


### PR DESCRIPTION
- added missing `ls -la .next` command in Jenkinsfile.
- restored `COPY` commands in Dockerfile for proper builds.
- removed redundant `cp` commands in Dockerfile.