### PR TITLE
Simplify Dockerfile by removing image cache path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@ FROM node:lts-alpine AS runner
 
 WORKDIR /app
 
-RUN mkdir -p /app/.next/cache/images
-
 COPY .next/standalone ./
 COPY .next/static ./.next/static
 COPY public ./public


### PR DESCRIPTION
- removed creation of `/app/.next/cache/images` directory.
- streamlined Dockerfile to focus on essential steps.