### PR TITLE
Remove redundant corepack prepare command

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ pipeline {
 						)
 					]) {
 						sh '''
-							corepack enable && corepack prepare yarn@stable --activate
+							corepack enable
 							yarn
 						'''
 					}


### PR DESCRIPTION
- removed the `corepack prepare yarn@stable --activate` command.
- kept `corepack enable` and `yarn` commands intact.