### PR TITLE
Ensure corepack works with missing Yarn releases dir

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ pipeline {
 						)
 					]) {
 						sh '''
-							corepack enable
+							mkdir -p .yarn/releases && corepack enable
 							yarn
 						'''
 					}


### PR DESCRIPTION
- added `mkdir -p .yarn/releases` to create directory if missing.