### PR TITLE
fix: update corepack command for Yarn activation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ pipeline {
 						)
 					]) {
 						sh '''
-							mkdir -p .yarn/releases && corepack enable
+							corepack enable && corepack prepare yarn@4.7.0 --activate
 							yarn
 						'''
 					}


### PR DESCRIPTION
- replaced `mkdir -p .yarn/releases` with `corepack prepare yarn@4.7.0 --activate`.